### PR TITLE
Update eventSize to recordingMetadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-rrweb-player",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "React-based player for rrweb",
   "author": "macobo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-react-rrweb-player",
-  "version": "1.0.10",
+  "version": "1.0.9",
   "description": "React-based player for rrweb",
   "author": "macobo",
   "license": "MIT",

--- a/src/eventIndex.ts
+++ b/src/eventIndex.ts
@@ -8,8 +8,10 @@ export interface PageMetadata extends Metadata {
     href: string
 }
 
-export interface SizeMetadata extends Metadata {
-    size: string
+export interface RecordingMetadata extends Metadata {
+    resolution: string
+    width: number
+    height: number
 }
 
 export interface LibCustomEvent {
@@ -39,10 +41,10 @@ export class EventIndex {
     ): [PageMetadata, number] | [null, -1] =>
         this._findCurrent(playerTime, this.pageChangeEvents())
 
-    getSizeMetadata = (
+    getRecordingMetadata = (
         playerTime: number
-    ): [SizeMetadata, number] | [null, -1] =>
-        this._findCurrent(playerTime, this.sizeEvents())
+    ): [RecordingMetadata, number] | [null, -1] =>
+        this._findCurrent(playerTime, this.recordingMetadata())
 
     pageChangeEvents = (): PageMetadata[] =>
         this._filterBy('href', (event) => {
@@ -65,12 +67,14 @@ export class EventIndex {
             return null
         })
 
-    sizeEvents = (): SizeMetadata[] =>
+    recordingMetadata = (): RecordingMetadata[] =>
         this._filterBy('size', (event) => {
             if ('width' in event.data && 'height' in event.data) {
                 const { width, height } = event.data
                 return {
-                    size: `${width} x ${height}`,
+                    resolution: `${width} x ${height}`,
+                    height: height,
+                    width: width,
                     playerTime: event.timestamp - this.baseTime
                 }
             }


### PR DESCRIPTION
## Changes

- Updates﻿`eventSize` references to `recordingMetadata` to add clarity to what information can be found, (internal attribute names updated too).
- Sends raw width & height on the `recordingMetadata` payload to allow target client to use custom formatting or add resolution-dependent logic (e.g. showing a different icon depending on the recording's width).

