### PR TITLE
Upgrade use-debounce, release @posthog/ package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 
 # ide
 .vscode/
+.idea

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# posthog-react-rrweb-player
+# @posthog/react-rrweb-player
 
 > React-based player for rrweb
 
-[![NPM](https://img.shields.io/npm/v/posthog-react-rrweb-player.svg)](https://www.npmjs.com/package/posthog-react-rrweb-player) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![NPM](https://img.shields.io/npm/v/@posthog/react-rrweb-player.svg)](https://www.npmjs.com/package/@posthog/react-rrweb-player) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 ## Install
 
 ```bash
-npm install --save posthog-react-rrweb-player
+npm install --save @posthog/react-rrweb-player
 ```
 
 ## Usage
@@ -15,8 +15,8 @@ npm install --save posthog-react-rrweb-player
 ```tsx
 import React, { Component } from 'react'
 
-import MyComponent from 'posthog-react-rrweb-player'
-import 'posthog-react-rrweb-player/dist/index.css'
+import MyComponent from '@posthog/react-rrweb-player'
+import '@posthog/react-rrweb-player/dist/index.css'
 
 class Example extends Component {
     render() {

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
     "@types/react": "link:../node_modules/@types/react",
     "@types/react-dom": "link:../node_modules/@types/react-dom",
     "@types/react-select": "^3.0.26",
-    "posthog-react-rrweb-player": "link:..",
+    "@posthog/react-rrweb-player": "link:..",
     "react": "link:../node_modules/react",
     "react-dom": "link:../node_modules/react-dom",
     "react-scripts": "link:../node_modules/react-scripts",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 
-import { EventIndex, formatTime, Player, PlayerRef } from 'posthog-react-rrweb-player'
+import { EventIndex, formatTime, Player, PlayerRef } from '@posthog/react-rrweb-player'
 import useLocalStorageState from 'use-local-storage-state'
 import Select from 'react-select'
 import { eventWithTime } from 'rrweb/typings/types'
 
-import 'posthog-react-rrweb-player/dist/index.css'
+import '@posthog/react-rrweb-player/dist/index.css'
 import 'rc-tooltip/assets/bootstrap.css'
 
 const makeOption = (label: string) => ({ value: window.location.pathname + label, label })

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1442,6 +1442,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@posthog/react-rrweb-player@link:..":
+  version "0.0.0"
+  uid ""
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
@@ -8590,10 +8594,6 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
-
-"posthog-react-rrweb-player@link:..":
-  version "0.0.0"
-  uid ""
 
 prelude-ls@~1.1.2:
   version "1.1.2"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4712,6 +4712,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@^0.4.4:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -7639,7 +7644,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@^1.0.11, pako@~1.0.5:
+pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -9382,21 +9387,21 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rrweb-snapshot@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-0.8.4.tgz#3f8bf1270975f9dfad60321a29067d2ea39e3c39"
-  integrity sha512-6zY4lEUpA6qEd/ArAo1crWefxsmiXMuK/fTToGmsW+ehR8/pglxTsqpMPEkgQO9uBUIWIUE9I3CyIQkigmt4ug==
+rrweb-snapshot@^1.0.3:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.0.7.tgz#9d334590089af4a857970ef4e9e978d986a122d1"
+  integrity sha512-6fu9+KiQlFPkFk2SdahIDsV+yu1juiAR/o+kOiwKPbXur1TiFGMPAfaQNCkqLc8Nvyx3ItkJmrIldyxnAalEag==
 
-rrweb@^0.9.9:
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-0.9.9.tgz#d502271f08620cd880a2be452e78ab78186173cb"
-  integrity sha512-w7KcyQp4r1vhHmPfxSnk2JriDdR9F9w6ABnEylwfhKjQR267T3WEYh9niRc1CBvXIrybTk6bzMuOqqXg4ziOWw==
+rrweb@^0.9.14:
+  version "0.9.14"
+  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-0.9.14.tgz#09bec604fc44c74801e4fe910606e5a6cde008ec"
+  integrity sha512-nm2rrVNoyWFPrbGQmcvTTlA7XjbbgPIgO7qsW0Zyr5iOURIFJDGPHFmOVLRyLpWiriVtEoXh6a+x+D1sj+qwWg==
   dependencies:
     "@types/css-font-loading-module" "0.0.4"
     "@xstate/fsm" "^1.4.0"
+    fflate "^0.4.4"
     mitt "^1.1.3"
-    pako "^1.0.11"
-    rrweb-snapshot "^0.8.4"
+    rrweb-snapshot "^1.0.3"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -10596,10 +10601,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-debounce@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.1.0.tgz#3df34bd7449da7dd2dbb10a6513efe701fc79d02"
-  integrity sha512-fU7O7iel2bA19fxSiPfRkieVGxrow503phSUAGZ/EqiJtCPrU9AdUdrKOAdgh803IrjdIzhj+8eDsDGn4OPy8g==
+use-debounce@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.2.1.tgz#7366543c769f1de3e92104dee64de5c4dfddfd33"
+  integrity sha512-BQG5uEypYHd/ASF6imzYR8tJHh5qGn28oZG/5iVAbljV6MUrfyT4jzxA8co+L+WLCT1U8VBwzzvlb3CHmUDpEA==
 
 use-local-storage-state@^6.0.0:
   version "6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "posthog-react-rrweb-player",
+  "name": "@posthog/react-rrweb-player",
   "version": "1.0.12",
   "description": "React-based player for rrweb",
   "author": "macobo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/react-rrweb-player",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "React-based player for rrweb",
   "author": "macobo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-transition-group": "^4.4.1",
     "rrweb": "^0.9.14",
     "screenfull": "^5.0.2",
-    "use-debounce": "^5.1.0",
+    "use-debounce": "^5.2.1",
     "use-local-storage-state": "^6.0.0"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import {
 import { Replayer } from 'rrweb'
 import screenfull from 'screenfull'
 import useLocalStorageState from 'use-local-storage-state'
-import { useDebouncedCallback } from 'use-debounce/lib'
+import { useDebouncedCallback } from 'use-debounce'
 import { eventWithTime, playerMetaData } from 'rrweb/typings/types'
 
 import { formatTime } from './time'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11540,10 +11540,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-debounce@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.1.0.tgz#3df34bd7449da7dd2dbb10a6513efe701fc79d02"
-  integrity sha512-fU7O7iel2bA19fxSiPfRkieVGxrow503phSUAGZ/EqiJtCPrU9AdUdrKOAdgh803IrjdIzhj+8eDsDGn4OPy8g==
+use-debounce@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.2.1.tgz#7366543c769f1de3e92104dee64de5c4dfddfd33"
+  integrity sha512-BQG5uEypYHd/ASF6imzYR8tJHh5qGn28oZG/5iVAbljV6MUrfyT4jzxA8co+L+WLCT1U8VBwzzvlb3CHmUDpEA==
 
 use-local-storage-state@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
- Upgrades `use-debounce` to 5.2.1
- Changes its import from `require("use-debounce/lib")` to `require("use-debounce")` to fix importing the package in Webpack 5
- Released the package under the @posthog/ namespace.
- Will deprecate the old package in npm after