### PR TITLE
Use addEvent api to react to new events being loaded dynamically

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/src/eventIndex.ts
+++ b/src/eventIndex.ts
@@ -34,7 +34,10 @@ export class EventIndex {
     }
 
     getDuration = (): number =>
-        this.events[this.events.length - 1].timestamp - this.events[0].timestamp
+        this.events.length > 0
+            ? this.events[this.events.length - 1].timestamp -
+              this.events[0].timestamp
+            : 0
 
     getPageMetadata = (
         playerTime: number

--- a/src/eventIndex.ts
+++ b/src/eventIndex.ts
@@ -34,10 +34,7 @@ export class EventIndex {
     }
 
     getDuration = (): number =>
-        this.events.length > 0
-            ? this.events[this.events.length - 1].timestamp -
-              this.events[0].timestamp
-            : 0
+        this.events[this.events.length - 1].timestamp - this.events[0].timestamp
 
     getPageMetadata = (
         playerTime: number

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,6 +110,19 @@ export const Player = forwardRef<PlayerRef, Props>(function Player(
         }
     }, [])
 
+    useEffect(() => {
+        if (frame.current && replayer.current) {
+            // Only add the events that don't already exist in replayer's context
+            const numCurrentEvents =
+                replayer.current?.service.state.context.events.length ?? 0
+            const eventsToAdd = props.events.slice(numCurrentEvents) ?? []
+            eventsToAdd.forEach((event) => replayer.current?.addEvent(event))
+
+            const meta = replayer.current.getMetaData()
+            setMeta(meta)
+        }
+    }, [props.events.length])
+
     useEffect((): any => {
         stopTimer()
 


### PR DESCRIPTION
This PR adds functionality to the `<Player/>` component such that the rrweb player can append new events being dynamically loaded. This allows us to pre-buffer the recording in segmented chunks which reduces first paint time drastically for long session recordings.

https://github.com/PostHog/posthog/pull/6270 depends on this change